### PR TITLE
Fix: stack overflow on large arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "af-streams",
-  "version": "3.1.55",
+  "version": "3.1.56",
   "description": "Data stream from database table",
   "main": "./dist/cjs/src/index.js",
   "module": "./dist/esm/index.js",

--- a/src/classes/keyed/KeyedTimeWindow.ts
+++ b/src/classes/keyed/KeyedTimeWindow.ts
@@ -150,7 +150,11 @@ export class KeyedTimeWindow<T, S = any> {
     Object.entries(hash).forEach(([key, timeWindow]) => {
       const removed = timeWindow.removeExpired(virtualTs);
       timeWindow.setStat({ timeWindow, winInsertType: EWinInsertType.REMOVE, removed });
-      removedFromAllTW.push(...removed);
+      // Fix: use for-loop instead of spread to avoid stack overflow on large arrays
+      // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#using_apply_and_built-in_functions
+      for (let i = 0; i < removed.length; i++) {
+        removedFromAllTW.push(removed[i]);
+      }
       if (!timeWindow.win.length) {
         delete hash[key];
       }


### PR DESCRIPTION
Use for-loop instead of spread to avoid stack overflow on large arrays